### PR TITLE
Fixed output from IdentifyStructure

### DIFF
--- a/R/IdentifyStructure.R
+++ b/R/IdentifyStructure.R
@@ -1,48 +1,59 @@
-IdentifyStructure=function(metacom.obj) {
+IdentifyStructure = function(metacom.obj) {
   #Coherence
   if(as.numeric(t(metacom.obj$Coherence)[,3]) >= 0.05) "Random" else
+   
     if(as.numeric(t(metacom.obj$Coherence)[,1]) < as.numeric(t(metacom.obj$Coherence)[,4]) & 
          as.numeric(t(metacom.obj$Coherence)[,3]) < 0.05) "Checkerboard (negative coherence)" else
+           
            if(as.numeric(t(metacom.obj$Coherence)[,1]) >= as.numeric(t(metacom.obj$Coherence)[,4]) & 
                 as.numeric(t(metacom.obj$Coherence)[,3]) < 0.05) {
-             print("Positive coherence...")
+
              #Significant positive turnover
              if(as.numeric(t(metacom.obj$Turnover)[,1]) >= as.numeric(t(metacom.obj$Turnover)[,4]) &
-                  as.numeric(t(metacom.obj$Turnover)[,3]) <= 0.05 &
+                  as.numeric(t(metacom.obj$Turnover)[,3]) < 0.05 &
                   metacom.obj$Boundary[,1] >=0 & metacom.obj$Boundary[,2] < 0.05) "Clementsian" else
+                    
                     if(as.numeric(t(metacom.obj$Turnover)[,1]) >= as.numeric(t(metacom.obj$Turnover)[,4]) &
-                         as.numeric(t(metacom.obj$Turnover)[,3]) <= 0.05 &
-                         metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] >= 0.05) "Gleasonian" else
+                         as.numeric(t(metacom.obj$Turnover)[,3]) < 0.05 & metacom.obj$Boundary[,2] >= 0.05) "Gleasonian" else
+                           
                            if(as.numeric(t(metacom.obj$Turnover)[,1]) >= as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                as.numeric(t(metacom.obj$Turnover)[,3]) <= 0.05 &
+                                as.numeric(t(metacom.obj$Turnover)[,3]) < 0.05 &
                                 metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] < 0.05) "Evenly spaced" else
+                                  
                                   #Significant negative turnover
                                   if(as.numeric(t(metacom.obj$Turnover)[,1]) < as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                       as.numeric(t(metacom.obj$Turnover)[,3]) <= 0.05 &
+                                       as.numeric(t(metacom.obj$Turnover)[,3]) < 0.05 &
                                        metacom.obj$Boundary[,1] >=0 & metacom.obj$Boundary[,2] < 0.05) "Nested (clumped)" else
+                                         
                                          if(as.numeric(t(metacom.obj$Turnover)[,1]) < as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                              as.numeric(t(metacom.obj$Turnover)[,3]) <= 0.05 &
-                                              metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] >= 0.05) "Nested (random)" else
+                                              as.numeric(t(metacom.obj$Turnover)[,3]) < 0.05 & metacom.obj$Boundary[,2] >= 0.05) "Nested (random)" else
+                                                
                                                 if(as.numeric(t(metacom.obj$Turnover)[,1]) < as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                                     as.numeric(t(metacom.obj$Turnover)[,3]) <= 0.05 &
+                                                     as.numeric(t(metacom.obj$Turnover)[,3]) < 0.05 &
                                                      metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] < 0.05) "Nested (hyperdispersed" else
+                                                       
                                                        #Non-significant positive turnover
                                                        if(as.numeric(t(metacom.obj$Turnover)[,1]) >= as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                                            as.numeric(t(metacom.obj$Turnover)[,3]) > 0.05 &
+                                                            as.numeric(t(metacom.obj$Turnover)[,3]) >= 0.05 &
                                                             metacom.obj$Boundary[,1] >=0 & metacom.obj$Boundary[,2] < 0.05) "Quasi-clementsian" else
+                                                              
                                                               if(as.numeric(t(metacom.obj$Turnover)[,1]) >= as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                                                   as.numeric(t(metacom.obj$Turnover)[,3]) > 0.05 &
-                                                                   metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] >= 0.05) "Quasi-gleasonian" else
+                                                                   as.numeric(t(metacom.obj$Turnover)[,3]) >= 0.05 & metacom.obj$Boundary[,2] >= 0.05) "Quasi-gleasonian" else
+                                                                     
                                                                      if(as.numeric(t(metacom.obj$Turnover)[,1]) >= as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                                                          as.numeric(t(metacom.obj$Turnover)[,3]) > 0.05 &
+                                                                          as.numeric(t(metacom.obj$Turnover)[,3]) >= 0.05 &
                                                                           metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] < 0.05) "Quasi-evenly spaced" else
+                                                                            
                                                                             #Non-significant negative turnover
                                                                             if(as.numeric(t(metacom.obj$Turnover)[,1]) < as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                                                                 as.numeric(t(metacom.obj$Turnover)[,3]) > 0.05 &
+                                                                                 as.numeric(t(metacom.obj$Turnover)[,3]) >= 0.05 &
                                                                                  metacom.obj$Boundary[,1] >=0 & metacom.obj$Boundary[,2] < 0.05) "Quasi-nested (clumped)" else
+                                                                                   
                                                                                    if(as.numeric(t(metacom.obj$Turnover)[,1]) < as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                                                                        as.numeric(t(metacom.obj$Turnover)[,3]) > 0.05 &
-                                                                                        metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] >= 0.05) "Quasi-nested (random)" else
+                                                                                        as.numeric(t(metacom.obj$Turnover)[,3]) >= 0.05 & metacom.obj$Boundary[,2] >= 0.05) "Quasi-nested (random)" else
+                                                                                          
                                                                                           if(as.numeric(t(metacom.obj$Turnover)[,1]) < as.numeric(t(metacom.obj$Turnover)[,4]) &
-                                                                                               as.numeric(t(metacom.obj$Turnover)[,3]) > 0.05 &
-                                                                                               metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] < 0.05) "Quasi-nested (hyperdispersed)" } } 
+                                                                                               as.numeric(t(metacom.obj$Turnover)[,3]) >= 0.05 &
+                                                                                               metacom.obj$Boundary[,1] < 0 & metacom.obj$Boundary[,2] < 0.05) "Quasi-nested (hyperdispersed)" }
+
+}

--- a/man/IdentifyStructure.Rd
+++ b/man/IdentifyStructure.Rd
@@ -34,7 +34,7 @@ Ouputs a classification of the metacommunity.
 
 
 \author{
-John Lefcheck
+Jon Lefcheck
 }
 
 \note{
@@ -44,15 +44,12 @@ Quasi structures, as well as 'random' and 'Gleasonian' structures, may not stric
 
 
 \examples{
-# Define an interaction matrix
+# Define interaction matrices
 data(TestMatrices)
-pres3c=TestMatrices[[6]]
 
-# Analyze metacommunity
-pres3c.metacom=Metacommunity(pres3c, sims=10, method='r1')
-
-# Identify the structure
-IdentifyStructure(pres3c.metacom)
+# Analyze metacommunity & Identify the structure
+metacom.list = lapply(TestMatrices[-1], function(i) Metacommunity(i))
+lapply(metacom.list, IdentifyStructure)
 
 }
 


### PR DESCRIPTION
No longer prints "Positive coherence" and simply outputs structure
